### PR TITLE
Rebase chore: refactor mappings

### DIFF
--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -466,13 +466,13 @@ export class FairSaleBid extends Entity {
     this.set("tokenOutAmount", Value.fromBigInt(value));
   }
 
-  get ownerId(): string {
-    let value = this.get("ownerId");
+  get owner(): string {
+    let value = this.get("owner");
     return value.toString();
   }
 
-  set ownerId(value: string) {
-    this.set("ownerId", Value.fromString(value));
+  set owner(value: string) {
+    this.set("owner", Value.fromString(value));
   }
 }
 
@@ -657,6 +657,23 @@ export class FixedPriceSale extends Entity {
       this.set("purchases", Value.fromStringArray(value as Array<string>));
     }
   }
+
+  get claims(): Array<string> | null {
+    let value = this.get("claims");
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toStringArray();
+    }
+  }
+
+  set claims(value: Array<string> | null) {
+    if (value === null) {
+      this.unset("claims");
+    } else {
+      this.set("claims", Value.fromStringArray(value as Array<string>));
+    }
+  }
 }
 
 export class FixedPriceSalePurchase extends Entity {
@@ -684,6 +701,91 @@ export class FixedPriceSalePurchase extends Entity {
       "FixedPriceSalePurchase",
       id
     ) as FixedPriceSalePurchase | null;
+  }
+
+  get id(): string {
+    let value = this.get("id");
+    return value.toString();
+  }
+
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
+
+  get createdAt(): i32 {
+    let value = this.get("createdAt");
+    return value.toI32();
+  }
+
+  set createdAt(value: i32) {
+    this.set("createdAt", Value.fromI32(value));
+  }
+
+  get updatedAt(): i32 {
+    let value = this.get("updatedAt");
+    return value.toI32();
+  }
+
+  set updatedAt(value: i32) {
+    this.set("updatedAt", Value.fromI32(value));
+  }
+
+  get deletedAt(): i32 {
+    let value = this.get("deletedAt");
+    return value.toI32();
+  }
+
+  set deletedAt(value: i32) {
+    this.set("deletedAt", Value.fromI32(value));
+  }
+
+  get sale(): string {
+    let value = this.get("sale");
+    return value.toString();
+  }
+
+  set sale(value: string) {
+    this.set("sale", Value.fromString(value));
+  }
+
+  get buyer(): Bytes {
+    let value = this.get("buyer");
+    return value.toBytes();
+  }
+
+  set buyer(value: Bytes) {
+    this.set("buyer", Value.fromBytes(value));
+  }
+
+  get amount(): BigInt {
+    let value = this.get("amount");
+    return value.toBigInt();
+  }
+
+  set amount(value: BigInt) {
+    this.set("amount", Value.fromBigInt(value));
+  }
+}
+
+export class FixedPriceSaleClaim extends Entity {
+  constructor(id: string) {
+    super();
+    this.set("id", Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(id !== null, "Cannot save FixedPriceSaleClaim entity without an ID");
+    assert(
+      id.kind == ValueKind.STRING,
+      "Cannot save FixedPriceSaleClaim entity with non-string ID. " +
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("FixedPriceSaleClaim", id.toString(), this);
+  }
+
+  static load(id: string): FixedPriceSaleClaim | null {
+    return store.get("FixedPriceSaleClaim", id) as FixedPriceSaleClaim | null;
   }
 
   get id(): string {
@@ -821,54 +923,6 @@ export class Token extends Entity {
 
   set decimals(value: BigInt) {
     this.set("decimals", Value.fromBigInt(value));
-  }
-}
-
-export class SaleUser extends Entity {
-  constructor(id: string) {
-    super();
-    this.set("id", Value.fromString(id));
-  }
-
-  save(): void {
-    let id = this.get("id");
-    assert(id !== null, "Cannot save SaleUser entity without an ID");
-    assert(
-      id.kind == ValueKind.STRING,
-      "Cannot save SaleUser entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.'
-    );
-    store.set("SaleUser", id.toString(), this);
-  }
-
-  static load(id: string): SaleUser | null {
-    return store.get("SaleUser", id) as SaleUser | null;
-  }
-
-  get id(): string {
-    let value = this.get("id");
-    return value.toString();
-  }
-
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
-  }
-
-  get address(): Bytes | null {
-    let value = this.get("address");
-    if (value === null || value.kind == ValueKind.NULL) {
-      return null;
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set address(value: Bytes | null) {
-    if (value === null) {
-      this.unset("address");
-    } else {
-      this.set("address", Value.fromBytes(value as Bytes));
-    }
   }
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -102,7 +102,7 @@ type FairSaleBid implements EntityMetadata @entity {
   "Number of tokens the investor wants to buy"
   tokenOutAmount: BigInt!
   "The owner of the Bid"
-  ownerId: FairSaleUser!
+  owner: FairSaleUser!
 }
 
 #################################################

--- a/src/helpers/fairSale.ts
+++ b/src/helpers/fairSale.ts
@@ -28,25 +28,25 @@ export class Order {
   static decodeFromBytes(bytes: Bytes): Order {
     return new Order(bytes)
   }
-}
 
-/**
- * Encodes a Order into a Bytes string
- */
-export function encodeOrder(ownerId: BigInt, orderTokenOut: BigInt, orderTokenIn: BigInt): string {
-  return (
-    '0x' +
-    ownerId
-      .toString()
-      .slice(2)
-      .padStart(16, '0') +
-    orderTokenOut
-      .toString()
-      .slice(2)
-      .padStart(24, '0') +
-    orderTokenIn
-      .toString()
-      .slice(2)
-      .padStart(24, '0')
-  )
+  /**
+   * Encodes a Order into a Bytes string
+   */
+  static encodeOrder(ownerId: BigInt, orderTokenOut: BigInt, orderTokenIn: BigInt): string {
+    return (
+      '0x' +
+      ownerId
+        .toString()
+        .slice(2)
+        .padStart(16, '0') +
+      orderTokenOut
+        .toString()
+        .slice(2)
+        .padStart(24, '0') +
+      orderTokenIn
+        .toString()
+        .slice(2)
+        .padStart(24, '0')
+    )
+  }
 }

--- a/src/helpers/fairSale.ts
+++ b/src/helpers/fairSale.ts
@@ -1,0 +1,51 @@
+import { Bytes, BigInt } from '@graphprotocol/graph-ts'
+
+export class Order {
+  _ownerId: BigInt
+  _tokenIn: BigInt
+  _tokenOut: BigInt
+
+  private constructor(bytes: Bytes) {
+    let byesString = bytes.toString()
+    this._ownerId = BigInt.fromI32(Bytes.fromHexString('0x' + byesString.substring(2, 18)).toI32())
+    this._tokenIn = BigInt.fromI32(Bytes.fromHexString('0x' + byesString.substring(43, 66)).toI32())
+    this._tokenOut = BigInt.fromI32(Bytes.fromHexString('0x' + byesString.substring(19, 42)).toI32())
+  }
+
+  get ownerId(): BigInt {
+    return this._ownerId
+  }
+
+  get tokenOut(): BigInt {
+    return this._tokenIn
+  }
+
+  get tokenIn(): BigInt {
+    return this._tokenIn
+  }
+
+  static decodeFromBytes(bytes: Bytes): Order {
+    return new Order(bytes)
+  }
+}
+
+/**
+ * Encodes a Order into a Bytes string
+ */
+export function encodeOrder(ownerId: BigInt, orderTokenOut: BigInt, orderTokenIn: BigInt): string {
+  return (
+    '0x' +
+    ownerId
+      .toString()
+      .slice(2)
+      .padStart(16, '0') +
+    orderTokenOut
+      .toString()
+      .slice(2)
+      .padStart(24, '0') +
+    orderTokenIn
+      .toString()
+      .slice(2)
+      .padStart(24, '0')
+  )
+}

--- a/src/helpers/fairSale.ts
+++ b/src/helpers/fairSale.ts
@@ -1,4 +1,4 @@
-import { Bytes, BigInt, ethereum, Value } from '@graphprotocol/graph-ts'
+import { Bytes, BigInt, ethereum } from '@graphprotocol/graph-ts'
 
 export class Order {
   _ownerId: ethereum.Value

--- a/src/helpers/fairSale.ts
+++ b/src/helpers/fairSale.ts
@@ -1,27 +1,28 @@
-import { Bytes, BigInt } from '@graphprotocol/graph-ts'
+import { Bytes, BigInt, ethereum, Value } from '@graphprotocol/graph-ts'
 
 export class Order {
-  _ownerId: BigInt
-  _tokenIn: BigInt
-  _tokenOut: BigInt
+  _ownerId: ethereum.Value
+  _tokenIn: ethereum.Value
+  _tokenOut: ethereum.Value
 
   private constructor(bytes: Bytes) {
     let byesString = bytes.toString()
-    this._ownerId = BigInt.fromI32(Bytes.fromHexString('0x' + byesString.substring(2, 18)).toI32())
-    this._tokenIn = BigInt.fromI32(Bytes.fromHexString('0x' + byesString.substring(43, 66)).toI32())
-    this._tokenOut = BigInt.fromI32(Bytes.fromHexString('0x' + byesString.substring(19, 42)).toI32())
+
+    this._ownerId = ethereum.Value.fromString('0x' + byesString.substring(2, 18))
+    this._tokenIn = ethereum.Value.fromString('0x' + byesString.substring(43, 66))
+    this._tokenOut = ethereum.Value.fromString('0x' + byesString.substring(19, 42))
   }
 
   get ownerId(): BigInt {
-    return this._ownerId
+    return this._ownerId.toBigInt()
   }
 
   get tokenOut(): BigInt {
-    return this._tokenIn
+    return this._tokenIn.toBigInt()
   }
 
   get tokenIn(): BigInt {
-    return this._tokenIn
+    return this._tokenIn.toBigInt()
   }
 
   static decodeFromBytes(bytes: Bytes): Order {

--- a/src/mappings/saleLauncher.ts
+++ b/src/mappings/saleLauncher.ts
@@ -9,6 +9,7 @@ import { SaleInitialized } from '../../generated/SaleLauncher/SaleLauncher'
 // Helpers
 import { getSaleTemplateById, SALE_TEMPLATES } from '../helpers/templates'
 import { SALE_STATUS, getOrCreateSaleToken } from '../helpers/sales'
+import { Order } from '../helpers/fairSale'
 
 // GraphQL schemas
 import * as Schemas from '../../generated/schema'
@@ -61,7 +62,18 @@ function registerFairSale(event: SaleInitialized): Schemas.FairSale {
   fairSale.tokenOut = tokenOut.id
   // Sale name
   fairSale.name = tokenOut.name || ''
-  // Save
+
+  // Store/save the first order/bid
+  let decodedOrder = Order.decodeFromBytes(fairSaleContract.initialAuctionOrder())
+  let fairSaleBid = new Schemas.FairSaleBid('2324531242')
+  fairSaleBid.tokenInAmount = decodedOrder.tokenIn
+  fairSaleBid.tokenOutAmount = decodedOrder.tokenOut
+  // Update ref of FairSaleUser to ownerId
+  fairSaleBid.ownerId = decodedOrder.ownerId.toString()
+  fairSaleBid.sale = event.params.sale.toString()
+  // Save the bid to the database
+  fairSaleBid.save()
+  // Save the sale
   fairSale.save()
 
   return fairSale

--- a/src/mappings/saleLauncher.ts
+++ b/src/mappings/saleLauncher.ts
@@ -1,6 +1,5 @@
 // Externals
-import { BigInt } from '@graphprotocol/graph-ts'
-
+import { BigInt, store, json, ethereum, Value } from '@graphprotocol/graph-ts'
 // Contract Types and ABIs
 import { FixedPriceSale as FixedPriceSaleContract } from '../../generated/FixedPriceSale/FixedPriceSale'
 import { FairSale as FairSaleContract } from '../../generated/FairSale/FairSale'
@@ -8,12 +7,11 @@ import { SaleInitialized } from '../../generated/SaleLauncher/SaleLauncher'
 
 // Helpers
 import { getSaleTemplateById, SALE_TEMPLATES } from '../helpers/templates'
-import { SALE_STATUS, getOrCreateSaleToken } from '../helpers/sales'
+import { SALE_STATUS, getOrCreateSaleToken, BID_STATUS } from '../helpers/sales'
 import { Order } from '../helpers/fairSale'
 
 // GraphQL schemas
 import * as Schemas from '../../generated/schema'
-
 /**
  * Handle initializing an (Easy|FixedPrice)Sale via `SaleLauncher.createSale`
  * Determines the sale mechanism from `event.params.templateId` and
@@ -63,17 +61,37 @@ function registerFairSale(event: SaleInitialized): Schemas.FairSale {
   // Sale name
   fairSale.name = tokenOut.name || ''
 
-  // Store/save the first order/bid
-  let decodedOrder = Order.decodeFromBytes(fairSaleContract.initialAuctionOrder())
-  let fairSaleBid = new Schemas.FairSaleBid('2324531242')
-  fairSaleBid.tokenInAmount = decodedOrder.tokenIn
-  fairSaleBid.tokenOutAmount = decodedOrder.tokenOut
-  // Update ref of FairSaleUser to ownerId
-  fairSaleBid.ownerId = decodedOrder.ownerId.toString()
-  fairSaleBid.sale = event.params.sale.toString()
-  // Save the bid to the database
-  fairSaleBid.save()
-  // Save the sale
+  {
+    let fairSaleUserId = event.address.toHexString() + '/users/1' // The first user is always 1
+    // Register the FairSaleUser
+    // A predictable key is <saleAddress>-<userId>
+    let fairSaleUser = new Schemas.FairSaleUser(fairSaleUserId)
+    fairSaleUser.createdAt = event.block.timestamp.toI32()
+    fairSaleUser.updatedAt = event.block.timestamp.toI32()
+    fairSaleUser.address = event.transaction.from
+    fairSaleUser.ownerId = 1
+    fairSaleUser.sale = event.params.sale.toString()
+    fairSaleUser.save()
+
+    // Store/save the first order/bid
+    // This order has preditable values
+    // owner(Id) is always 1 because the contract registers ID
+    // tokenInAmount is the amount offered in the sale
+    // tokenOutAmount is the
+    let fairSaleBid = new Schemas.FairSaleBid(event.address.toHexString() + '/bids/1') // predictable
+    fairSaleBid.createdAt = event.block.timestamp.toI32()
+    fairSaleBid.updatedAt = event.block.timestamp.toI32()
+    fairSaleBid.tokenInAmount = fairSaleContract.tokensForSale()
+    fairSaleBid.tokenOutAmount = fairSaleContract.minimumBiddingAmountPerOrder()
+    fairSaleBid.status = BID_STATUS.SUBMITTED
+    // Update ref of FairSaleUser to ownerId
+    fairSaleBid.owner = fairSaleUserId // first bid is FairSaleUse always from the owner
+    fairSaleBid.sale = event.params.sale.toHexString()
+    // Save the bid to the database
+    fairSaleBid.save()
+    // Save the sale
+  }
+
   fairSale.save()
 
   return fairSale

--- a/src/mappings/sales/fairSale.ts
+++ b/src/mappings/sales/fairSale.ts
@@ -81,17 +81,19 @@ export function handleNewOrder(event: NewOrder): void {
     return
   }
   // Construct entity ID from the parameters
-  let orderId = encodeOrder(event.params.ownerId, event.params.orderTokenOut, event.params.orderTokenIn)
-  let bid = new Schemas.FairSaleBid(orderId)
-  bid.sale = event.address.toHexString()
+  // A bid is <saleAddress>/bids/<ownerId>/<block.timestamp>
+  let bid = new Schemas.FairSaleBid(
+    event.address.toHexString() + '/bids/' + event.params.ownerId.toString() + '/' + event.block.timestamp.toString()
+  )
+  bid.sale = event.address.toString()
   bid.createdAt = event.block.timestamp.toI32()
   bid.updatedAt = event.block.timestamp.toI32()
   bid.tokenInAmount = event.params.orderTokenIn
   bid.tokenOutAmount = event.params.orderTokenOut
   // Update FairSaleUser ref
-  bid.ownerId = event.transaction.from.toString()
+  bid.owner = event.transaction.from.toHexString()
   // Update FairSale ref
-  bid.sale = event.address.toString()
+  bid.sale = event.address.toHexString()
   bid.status = BID_STATUS.SUBMITTED
   // Save
   bid.save()
@@ -107,7 +109,8 @@ export function handleNewUser(event: NewUser): void {
   }
 
   // Use their address as unique id
-  let saleUser = new Schemas.FairSaleUser(event.params.ownerId.toHexString())
+  // A sale user id is <saleAddress>/users/<ownerId>
+  let saleUser = new Schemas.FairSaleUser(event.address.toHexString() + '/users/' + event.params.ownerId.toString())
   // Update ref to FairSale
   saleUser.sale = event.address.toString()
   saleUser.ownerId = event.params.ownerId.toI32()

--- a/src/mappings/sales/fairSale.ts
+++ b/src/mappings/sales/fairSale.ts
@@ -17,7 +17,6 @@ import * as Schemas from '../../../generated/schema'
 
 // Helpers
 import { SALE_STATUS, BID_STATUS } from '../../helpers/sales'
-import { encodeOrder } from '../../helpers/fairSale'
 
 /**
  * Handles any Auction that has cleared


### PR DESCRIPTION
**This is a clean-up PR from `v2/mappings` to rebase/clean up the repo.**

### New `FairSale` helpers
- `Order` class to decode Order Bytes
- `initialAuctionOrder` bytes can now be decoded - initial manual tests look promising.
### New entities
- Add `FairSaleUser` to store information about the sale users 


### Mappings
- Update fields hooks to reflect the new `FairSaleUser` schema. 
- Fix bug where the first user wasn't being saved due to event sequence in Solidity.