### PR TITLE
Add more `FixedPriceSaleUser.totalVolume`  aggerated property

### DIFF
--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -816,13 +816,22 @@ export class FixedPriceSaleUser extends Entity {
     this.set("deletedAt", Value.fromI32(value));
   }
 
-  get totalPurchases(): i32 {
-    let value = this.get("totalPurchases");
+  get totalPurchase(): i32 {
+    let value = this.get("totalPurchase");
     return value.toI32();
   }
 
-  set totalPurchases(value: i32) {
-    this.set("totalPurchases", Value.fromI32(value));
+  set totalPurchase(value: i32) {
+    this.set("totalPurchase", Value.fromI32(value));
+  }
+
+  get totalVolume(): BigInt {
+    let value = this.get("totalVolume");
+    return value.toBigInt();
+  }
+
+  set totalVolume(value: BigInt) {
+    this.set("totalVolume", Value.fromBigInt(value));
   }
 
   get sale(): string {

--- a/schema.graphql
+++ b/schema.graphql
@@ -168,7 +168,9 @@ type FixedPriceSaleUser implements EntityMetadata @entity {
   updatedAt: Int!
   deletedAt: Int
   "Total purchases submitted in the sale"
-  totalPurchases: Int!
+  totalPurchase: Int!
+  "Total volume for this user"
+  totalVolume: BigInt!
   "FixedPriceSale reference"
   sale: FixedPriceSale!
   "Address of buyer"

--- a/schema.graphql
+++ b/schema.graphql
@@ -107,6 +107,13 @@ type FairSaleBid implements EntityMetadata @entity {
 
 #################################################
 
+enum FixedPriceSaleStatus {
+  UPCOMING
+  SETTLED
+  ENDED
+  OPEN
+}
+
 # FixedPriceSale
 type FixedPriceSale implements EntityMetadata @entity {
   id: ID!
@@ -116,7 +123,7 @@ type FixedPriceSale implements EntityMetadata @entity {
   "The name of the same, default is the tokenIn's name"
   name: String!
   "Sale status: open/ended/settled/upcoming/cancelled/failed"
-  status: String!
+  status: FixedPriceSaleStatus!
   "The UTC timestamp at which the sale starts"
   startDate: Int! # Open timestamp
   "The UTC timestamp at which the sale closes"

--- a/src/helpers/fixedPriceSale.ts
+++ b/src/helpers/fixedPriceSale.ts
@@ -5,7 +5,7 @@ import { FixedPriceSaleUser } from '../../generated/schema'
 // Predefined Auction Bid status
 export abstract class PURCHASE_STATUS {
   static SUBMITTED: string = 'SUBMITTED'
-  static CLAIMED: string = 'claimed'
+  static CLAIMED: string = 'CLAIMED'
 }
 
 /**
@@ -50,7 +50,8 @@ export function createOrGetFixedPriceSaleUser(
   // Create them
   if (fixedPriceSaleUser == null) {
     fixedPriceSaleUser = new FixedPriceSaleUser(fixedPriceSaleUserId)
-    fixedPriceSaleUser.totalPurchases = 0
+    fixedPriceSaleUser.totalPurchase = 0
+    fixedPriceSaleUser.totalVolume = BigInt.fromI32(0)
     fixedPriceSaleUser.createdAt = timestamp.toI32()
     fixedPriceSaleUser.updatedAt = timestamp.toI32()
     fixedPriceSaleUser.sale = saleAddress.toHexString()
@@ -67,7 +68,7 @@ export function createOrGetFixedPriceSaleUser(
  * @param userAddres
  * @returns
  */
-export function getFixedPriceSaleUserTotalPurchases(fixedPriceSaleUserId: string): number {
+export function getFixedPriceSaleUserTotalPurchase(fixedPriceSaleUserId: string): number {
   // First, fetch or register the new user
   let fixedPriceSaleUser = FixedPriceSaleUser.load(fixedPriceSaleUserId)
 
@@ -75,5 +76,5 @@ export function getFixedPriceSaleUserTotalPurchases(fixedPriceSaleUserId: string
     return 0
   }
 
-  return fixedPriceSaleUser.totalPurchases
+  return fixedPriceSaleUser.totalPurchase
 }

--- a/src/helpers/sales.ts
+++ b/src/helpers/sales.ts
@@ -9,10 +9,10 @@ import { fetchTokenDecimals, fetchTokenName, fetchTokenSymbol } from './erc20'
 
 // Predefined Auction status
 export abstract class SALE_STATUS {
-  static UPCOMING: string = 'upcoming'
-  static SETTLED: string = 'settled'
-  static ENDED: string = 'ended'
-  static OPEN: string = 'open'
+  static UPCOMING: string = 'UPCOMING'
+  static SETTLED: string = 'SETTLED'
+  static ENDED: string = 'ENDED'
+  static OPEN: string = 'OPEN'
 }
 
 // Predefined Auction Bid status

--- a/src/mappings/saleLauncher.ts
+++ b/src/mappings/saleLauncher.ts
@@ -1,5 +1,5 @@
 // Externals
-import { BigInt, store, json, ethereum, Value } from '@graphprotocol/graph-ts'
+import { BigInt } from '@graphprotocol/graph-ts'
 // Contract Types and ABIs
 import { FixedPriceSale as FixedPriceSaleContract } from '../../generated/FixedPriceSale/FixedPriceSale'
 import { FairSale as FairSaleContract } from '../../generated/FairSale/FairSale'
@@ -8,7 +8,6 @@ import { SaleInitialized } from '../../generated/SaleLauncher/SaleLauncher'
 // Helpers
 import { getSaleTemplateById, SALE_TEMPLATES } from '../helpers/templates'
 import { SALE_STATUS, getOrCreateSaleToken, BID_STATUS } from '../helpers/sales'
-import { Order } from '../helpers/fairSale'
 
 // GraphQL schemas
 import * as Schemas from '../../generated/schema'

--- a/src/mappings/sales/fixedPriceSale.ts
+++ b/src/mappings/sales/fixedPriceSale.ts
@@ -1,6 +1,6 @@
 // Contract ABIs and Events
 import {
-  getFixedPriceSaleUserTotalPurchases,
+  getFixedPriceSaleUserTotalPurchase,
   createFixedPriceSalePurchaseId,
   createOrGetFixedPriceSaleUser,
   createFixedPriceSaleUserId,
@@ -47,9 +47,11 @@ export function handleNewPurchase(event: NewPurchase): void {
   // Get the user
   let fixedPriceSaleUser = createOrGetFixedPriceSaleUser(event.address, event.params.buyer, event.block.timestamp)
   // Increase the total purcahses by one and save
-  let newPurchaseIndex = fixedPriceSaleUser.totalPurchases + 1
   // Push change to FixedPriceSaleUser entity
-  fixedPriceSaleUser.totalPurchases = newPurchaseIndex
+  let newPurchaseIndex = fixedPriceSaleUser.totalPurchase + 1
+  fixedPriceSaleUser.totalPurchase = newPurchaseIndex
+  // Increase the total volume for user+sale pair
+  fixedPriceSaleUser.totalVolume = event.params.amount.plus(fixedPriceSaleUser.totalVolume)
   // Construct the purchase id
   let purchaseId = createFixedPriceSalePurchaseId(event.address, event.params.buyer, newPurchaseIndex)
   // Create the FixedPriceSalePurchase entity
@@ -74,9 +76,7 @@ export function handleNewPurchase(event: NewPurchase): void {
  */
 export function handleNewTokenClaim(event: NewTokenClaim): void {
   // Get total purchases by the investor/buyer
-  let totalPurchases = getFixedPriceSaleUserTotalPurchases(
-    createFixedPriceSaleUserId(event.address, event.params.buyer)
-  )
+  let totalPurchases = getFixedPriceSaleUserTotalPurchase(createFixedPriceSaleUserId(event.address, event.params.buyer))
   // Loop through the purchases and update their status for the buyer
   for (let purchaseIndex = 1; purchaseIndex <= totalPurchases; purchaseIndex++) {
     let purchase = FixedPriceSalePurchase.load(


### PR DESCRIPTION
This PR adds a few minor fixes and improvements to the previous attempt to add claims.

### New
1. Add `totalVolume` to track the total purchase volume concluded by a user per sale.

### Fixed
1. Use enums for `FixedPriceSale.status`
2. Remove unused imports