### PR TITLE
Update `TemplateLauncher` address

### DIFF
--- a/config/xdai.json
+++ b/config/xdai.json
@@ -9,7 +9,7 @@
       "address": "0xC28c613f0f0b85C745AC58BA78071816Cb52B43A"
     },
     "templateLauncher": {
-      "address": "0x2ce600a4f5F191029C32a240C504B041cc68f267"
+      "address": "0x58c67b46c47f69d63aa09d5f822ede377c479d5f"
     },
     "participantListLauncher": {
       "address": "0x50f0F32c7E3A5Fe68124086436af3fA73AA69030"


### PR DESCRIPTION
The old `TemplateLauncher` is no longer considered.