### PR TITLE
Feature - Deploy subgraph via GitHub workflows

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,9 @@ jobs:
         run: yarn install
       - name: Install modules
         run: yarn prepare-xdai
-      - name: Build and deploy
+      - name: Generate dist
         run: yarn codegen
-      - run: yarn build
-      - run: graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ adamazad/aqua-xdai
+      - name: Build
+        run: yarn build
+      - name: Deploy
+        run: graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ adamazad/aqua-xdai

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,12 +10,12 @@ jobs:
       - name: Install The Graph CLI
         run: yarn global add @graphprotocol/graph-cli
       - name: Add The Graph access token
-        run: graph auth --product hosted-service ${{ secrets.SECRET_TOKEN }}
+        run: graph auth --product hosted-service ${{ secrets.THE_GRAPH_ACCESS_TOKEN }}
       - name: Install modules
         run: yarn install
-      - name: Install modules
+      - name: Prepare subgraph.yaml
         run: yarn prepare-xdai
-      - name: Generate dist
+      - name: Generate migrations
         run: yarn codegen
       - name: Build
         run: yarn build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,11 +20,11 @@ jobs:
       - name: Install The Graph CLI
         run: yarn global add @graphprotocol/graph-cli
       - name: Add The Graph access token
-      - run: graph auth --node https://api.thegraph.com/deploy ${{ secrets.SECRET_TOKEN }}
+        run: graph auth --node https://api.thegraph.com/deploy ${{ secrets.SECRET_TOKEN }}
       - name: Install modules
-      - run: yarn install
+        run: yarn install
       - name: Install modules
-      - run: yarn prepare-xdai
+        run: yarn prepare-xdai
       - name: Build and deploy
         run: yarn codegen
         run: yarn build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,16 +2,8 @@
 name: Deploy
 
 on:
-  workflow_dispatch:
-    inputs:
-      network:
-        description: 'Target network - xdai or rinkeby'
-        required: true
-        default: 'xdai'
-      logLevel:
-        description: 'Log level'
-        required: true
-        default: 'warning'
+  workflow_dispatch
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,12 +16,16 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Graph CLI
       - uses: actions/checkout@v2
-      - run: yarn global add @graphprotocol/graph-cli
+      - name: Install The Graph CLI
+        run: yarn global add @graphprotocol/graph-cli
+      - name: Add The Graph access token
       - run: graph auth --node https://api.thegraph.com/deploy ${{ secrets.SECRET_TOKEN }}
+      - name: Install modules
       - run: yarn install
+      - name: Install modules
       - run: yarn prepare-xdai
-      - run: yarn codegen
-      - run: yarn build
-      - run: graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ adamazad/aqua-xdai
+      - name: Build and deploy
+        run: yarn codegen
+        run: yarn build
+        run: graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ adamazad/aqua-xdai

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,8 +1,6 @@
-# This workflow checkes if the graph is built
 name: Deploy
 
-on:
-  workflow_dispatch
+on: workflow_dispatch
 
 jobs:
   deploy:
@@ -19,5 +17,5 @@ jobs:
         run: yarn prepare-xdai
       - name: Build and deploy
         run: yarn codegen
-        run: yarn build
-        run: graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ adamazad/aqua-xdai
+      - run: yarn build
+      - run: graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ adamazad/aqua-xdai

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,27 @@
+# This workflow checkes if the graph is built
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        description: 'Target network - xdai or rinkeby'
+        required: true
+        default: 'xdai'
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Graph CLI
+      - uses: actions/checkout@v2
+      - run: yarn global add @graphprotocol/graph-cli
+      - run: graph auth --node https://api.thegraph.com/deploy ${{ secrets.SECRET_TOKEN }}
+      - run: yarn install
+      - run: yarn prepare-xdai
+      - run: yarn codegen
+      - run: yarn build
+      - run: graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ adamazad/aqua-xdai

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Install The Graph CLI
         run: yarn global add @graphprotocol/graph-cli
       - name: Add The Graph access token
-        run: graph auth --node https://api.thegraph.com/deploy ${{ secrets.SECRET_TOKEN }}
+        run: graph auth --product hosted-service ${{ secrets.SECRET_TOKEN }}
       - name: Install modules
         run: yarn install
       - name: Install modules

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,4 +20,4 @@ jobs:
       - name: Build
         run: yarn build
       - name: Deploy
-        run: graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ adamazad/aqua-xdai
+        run: graph deploy --product hosted-service adamazad/aqua-xdai


### PR DESCRIPTION
### Summary

Adds a new workflow to deploy the subgraph from GitHub repo directly. Requires setting secret `THE_GRAPH_ACCESS_TOKEN` which is currently set to my The Graph's account. 

When running the workflow, the user can select the branch the workflow should use as the source.

Notes:
- Anyone can trigger the workflow - I believe. One simple way to fix this is restricting the users.
- It currently supports one subgraph - `adamazad/aqua-xdai` and xDAI network. We can add more jobs to deploy to more networks in future PRs.