### PR TITLE
Hotfix - Patch prepare script issues

### DIFF
--- a/bin/prepare.ts
+++ b/bin/prepare.ts
@@ -28,7 +28,7 @@ export async function prepare(network: string) {
     encoding: 'utf8'
   })
   const subgraphYamlOut = render(subgraphYamlTemplate, {
-    startBLock: 16965430,
+    startBlock: 16965430,
     network,
     contracts: {
       aquaFactory: {


### PR DESCRIPTION
Simple typo caused the output `subgraph.yml` to miss block number