### PR TITLE
Bug - `handleNewTokenRelease` does not update commitments status

### DIFF
--- a/src/mappings/sales/fixedPriceSale.ts
+++ b/src/mappings/sales/fixedPriceSale.ts
@@ -107,8 +107,8 @@ export function handleNewTokenWithdraw(event: NewTokenWithdraw): void {
       commitment.save()
     }
   }
-
-  fixedPriceSale.status = SALE_STATUS.FAILED
+  // Set sale status as settled
+  fixedPriceSale.status = SALE_STATUS.SETTLED
   fixedPriceSale.save()
 }
 

--- a/src/mappings/sales/fixedPriceSale.ts
+++ b/src/mappings/sales/fixedPriceSale.ts
@@ -126,7 +126,10 @@ export function handleNewTokenRelease(event: NewTokenRelease): void {
   fixedPriceSale.save()
 }
 
-export function handleSaleInitialized(event: SaleInitialized): void { }
+/**
+ * Ignored, see `registerFixedPriceSale` in `saleLauncher.ts`
+ */
+export function handleSaleInitialized(event: SaleInitialized): void {}
 
 /**
  * Block handler to open sale

--- a/src/mappings/sales/fixedPriceSale.ts
+++ b/src/mappings/sales/fixedPriceSale.ts
@@ -72,9 +72,15 @@ export function handleNewCommitment(event: NewCommitment): void {
 }
 
 /**
- * WIP
+ * Handles cases when investors release their `tokenOut` after the sale has
+ * reached the minimum threshold and closed
  */
 export function handleNewTokenWithdraw(event: NewTokenWithdraw): void {
+  let fixedPriceSale = FixedPriceSale.load(event.address.toHexString())
+  if (!fixedPriceSale) {
+    return
+  }
+
   // Get the user
   let fixedPriceSaleUser = createOrGetFixedPriceSaleUser(event.address, event.params.user, event.block.timestamp)
   // Register the withdrawal
@@ -96,12 +102,14 @@ export function handleNewTokenWithdraw(event: NewTokenWithdraw): void {
     let commitment = FixedPriceSaleCommitment.load(
       createFixedPriceSaleCommitmentId(event.address, event.params.user, commitmentIndex)
     )
-
     if (commitment) {
       commitment.status = COMITMENT_STATUS.PROCESSED
       commitment.save()
     }
   }
+
+  fixedPriceSale.status = SALE_STATUS.FAILED
+  fixedPriceSale.save()
 }
 
 /**

--- a/src/mappings/sales/fixedPriceSale.ts
+++ b/src/mappings/sales/fixedPriceSale.ts
@@ -97,7 +97,7 @@ export function handleNewTokenWithdraw(event: NewTokenWithdraw): void {
   let totalCommitments = getFixedPriceSaleUserTotalCommitment(
     createFixedPriceSaleUserId(event.address, event.params.user)
   )
-  // Loop through the commitments and update their status for the buyer
+  // Loop through the commitments and update status for the buyer
   for (let commitmentIndex = 1; commitmentIndex <= totalCommitments; commitmentIndex++) {
     let commitment = FixedPriceSaleCommitment.load(
       createFixedPriceSaleCommitmentId(event.address, event.params.user, commitmentIndex)
@@ -113,16 +113,29 @@ export function handleNewTokenWithdraw(event: NewTokenWithdraw): void {
 }
 
 /**
- * WIP
+ * Handles cases when investors release their `tokenIn`. This happens due sales not reaching minimum threshold
  */
 export function handleNewTokenRelease(event: NewTokenRelease): void {
-  // tokens are swapped; sent to investors
   let fixedPriceSale = FixedPriceSale.load(event.address.toHexString())
   if (!fixedPriceSale) {
     return
   }
-
-  fixedPriceSale.status = SALE_STATUS.SETTLED
+  // Get total commitments by the investor/buyer
+  let totalCommitments = getFixedPriceSaleUserTotalCommitment(
+    createFixedPriceSaleUserId(event.address, event.params.user)
+  )
+  // Loop through the commitments and update status for the buyer
+  for (let commitmentIndex = 1; commitmentIndex <= totalCommitments; commitmentIndex++) {
+    let commitment = FixedPriceSaleCommitment.load(
+      createFixedPriceSaleCommitmentId(event.address, event.params.user, commitmentIndex)
+    )
+    if (commitment) {
+      commitment.status = COMITMENT_STATUS.RELEASED
+      commitment.save()
+    }
+  }
+  // Set sale status as failed
+  fixedPriceSale.status = SALE_STATUS.FAILED
   fixedPriceSale.save()
 }
 

--- a/tests/fixedPriceSale.spec.ts
+++ b/tests/fixedPriceSale.spec.ts
@@ -111,10 +111,8 @@ describe('FixedPriceSale', () => {
     const saleInfo = await launchedfixedPriceSale.saleInfo()
     // Open sale
     await mineBlock(aqua.provider, saleInfo.startDate.toNumber() + 180)
-    // Insure threshold is met
-    const commitTokensAmount = saleInfo.minRaise
-    // Commit tokens
-    await (await launchedfixedPriceSaleSaleInvestorB.commitTokens(commitTokensAmount)).wait()
+    // Insure threshold is met by committing the minimum raise
+    await (await launchedfixedPriceSaleSaleInvestorB.commitTokens(saleInfo.minRaise)).wait()
     // End sale
     await mineBlock(aqua.provider, saleInfo.endDate.toNumber() + 180)
     // Close sale
@@ -166,10 +164,8 @@ describe('FixedPriceSale', () => {
     const saleInfo = await launchedfixedPriceSale.saleInfo()
     // Open sale
     await mineBlock(aqua.provider, saleInfo.startDate.toNumber() + 180)
-    // Insure threshold is met
-    const commitTokensAmount = saleInfo.minRaise.sub(utils.formatEther(1))
-    // Commit tokens
-    await (await launchedfixedPriceSaleSaleInvestorB.commitTokens(commitTokensAmount)).wait()
+    // Commit tokens Insure threshold is not met by commit
+    await (await launchedfixedPriceSaleSaleInvestorB.commitTokens(saleInfo.minCommitment)).wait()
     // End sale
     await mineBlock(aqua.provider, saleInfo.endDate.toNumber() + 180)
     // Close sale


### PR DESCRIPTION
### Summary

- Closes #108 
- Amend `handleNewTokenRelease` to update all commitments status to `RELEASED`
- Fixes missing sale status update in `handleNewTokenWithdraw` to use `SETTLED`
- Fixes missing sale status update in `handleNewTokenRelease` to use `FAILED`
